### PR TITLE
update integration guide in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ The minimum supported versions are `12.0` for iOS and `10.13` for macOS.
 
 ### Swift Package Manager
 
+`Collections.xcframework` supports integration via Swift Package Manager starting from the `0.2.0` version.
+
+Follow these steps to import the Swift package:
+
+1. In Xcode, install the Google Mobile Ads Swift Package by navigating to File > Add Packages....
+
+1. In the prompt that appears, search for the Collections GitHub repository:
+
+```
+https://github.com/nikitapls/Collections
+```
+
+1. Select the version of the Collections Swift Package you want to use. For new projects, we recommend using the Up to Next Major Version.
+
 ### XCFramework
 
 There are two ways to get the `Collections.xcframework`:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are several ways to get the `Collections.xcframework`:
 1. Download the latest release version of the `Collections.xcramework` from this repository.
 1. Build the xcframework using [create_xcframework.sh](create_xcframework.sh) or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
 
-Once you have the `Collections.xcframework`, you can add it to your project. We recommend choosing the `Do not embed` option.
+Once you have the `Collections.xcframework`, you can add it to your project. We recommend choosing the `Do not embed` option to reduce the size of your target binary file.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ To run the code you need Swift version `5.10` or later, Xcode version `15.3` or 
 This framework supports both macOS and iOS application development.
 The minimum supported versions are `12.0` for iOS and `10.13` for macOS.
 
-## Usage
+## Integration
 
-To integrate the framework in your project:
+### Swift Package Manager
+
+### XCFramework
+
+There are two ways to get the `Collections.xcframework`:
 1. Download the latest release version of the `Collections.xcramework` from this repository.
-2. Add the `Collections.xcramework` to your project. We recommend you to choose the `Do not embed` option.
+2. Build the xcframework using `./create_xcframework.sh` or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
+
+Once you have the `Collections.xcframework`, you can add it to your project. We recommend choosing the `Do not embed` option.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,11 @@ The minimum supported versions are `12.0` for iOS and `10.13` for macOS.
 `Collections.xcframework` supports integration via Swift Package Manager starting from the `0.2.0` version.
 
 Follow these steps to import the Swift package:
-
 1. In Xcode, install the Google Mobile Ads Swift Package by navigating to File > Add Packages....
-
 1. In the prompt that appears, search for the Collections GitHub repository:
-
 ```
 https://github.com/nikitapls/Collections
 ```
-
 1. Select the version of the Collections Swift Package you want to use. For new projects, we recommend using the Up to Next Major Version.
 
 ### XCFramework

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ The minimum supported versions are `12.0` for iOS and `10.13` for macOS.
 
 Follow these steps to import the Swift package:
 1. In Xcode, install the Google Mobile Ads Swift Package by navigating to File > Add Packages....
-1. In the prompt that appears, search for the Collections GitHub repository:
+2. In the prompt that appears, search for the Collections GitHub repository:
 ```
 https://github.com/nikitapls/Collections
 ```
-1. Select the version of the Collections Swift Package you want to use. For new projects, we recommend using the Up to Next Major Version.
+3. Select the version of the Collections Swift Package you want to use. For new projects, we recommend using the Up to Next Major Version.
 
 ### XCFramework
 
 There are several ways to get the `Collections.xcframework`:
 1. Download the latest release version of the `Collections.xcramework` from this repository.
-1. Build the xcframework using `./create_xcframework.sh` or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
+1. Build the xcframework using [create_xcframework.sh](create_xcframework.sh) or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
 
 Once you have the `Collections.xcframework`, you can add it to your project. We recommend choosing the `Do not embed` option.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The minimum supported versions are `12.0` for iOS and `10.13` for macOS.
 `Collections.xcframework` supports integration via Swift Package Manager starting from the `0.2.0` version.
 
 Follow these steps to import the Swift package:
-1. In Xcode, install the Google Mobile Ads Swift Package by navigating to File > Add Packages....
+1. In Xcode, install the Collections Swift Package by navigating to File > Add Package dependencies....
 2. In the prompt that appears, search for the Collections GitHub repository:
 ```
 https://github.com/nikitapls/Collections

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ https://github.com/nikitapls/Collections
 
 ### XCFramework
 
-There are two ways to get the `Collections.xcframework`:
+There are several ways to get the `Collections.xcframework`:
 1. Download the latest release version of the `Collections.xcramework` from this repository.
-2. Build the xcframework using `./create_xcframework.sh` or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
+1. Build the xcframework using `./create_xcframework.sh` or you may follow the [instructions](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Create-archives-for-frameworks-or-libraries) provided by Apple.
 
 Once you have the `Collections.xcframework`, you can add it to your project. We recommend choosing the `Do not embed` option.
 


### PR DESCRIPTION
Closes #47, closes #31
This PR must be merged after the following:
- #49 
## List of changes
- added SPM integration guide. I used the [google documentation document](https://developers.google.com/admob/ios/quick-start#spm) for the inspiration.
- modified `.xcframework` integration guide