### PR TITLE
run linters

### DIFF
--- a/Collections/Collections/StackStatistics.swift
+++ b/Collections/Collections/StackStatistics.swift
@@ -1,5 +1,6 @@
 /// An ordered collection of elements that works as a stack.
-/// The order in which an element added to or removed from a stack is described as “last in, first out”,
+/// The order in which an element added to or removed from a stack
+/// is described as “last in, first out”,
 /// refer the `LastInFirstOutContainer` protocol for more details.
 /// In addition, data type allows to get simple statistics
 /// like the current minimum element among stored in the stack.

--- a/Collections/CollectionsTests/Stack/StackCountTests.swift
+++ b/Collections/CollectionsTests/Stack/StackCountTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackCountTests: XCTestCase {
     func test_count_withEmptyStack_returnsZero() {

--- a/Collections/CollectionsTests/Stack/StackGenericsTests.swift
+++ b/Collections/CollectionsTests/Stack/StackGenericsTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackGenericsTests: XCTestCase {
     func test_withVariousGenericParameters() {

--- a/Collections/CollectionsTests/Stack/StackIsEmptyTests.swift
+++ b/Collections/CollectionsTests/Stack/StackIsEmptyTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackIsEmptyTests: XCTestCase {
     func test_isEmpty_withEmptyStack_returnsTrue() {

--- a/Collections/CollectionsTests/Stack/StackIsStructureTests.swift
+++ b/Collections/CollectionsTests/Stack/StackIsStructureTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackIsStructureTests: XCTestCase {
     func test_stack_isStructure() {

--- a/Collections/CollectionsTests/Stack/StackPopTests.swift
+++ b/Collections/CollectionsTests/Stack/StackPopTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackPopTests: XCTestCase {
     var stack = Stack<Int>()
@@ -47,7 +47,7 @@ final class StackPopTests: XCTestCase {
 
     func test_pop_withNonEmptyStack_returnsElementsAccordingToLifo() {
         // Given
-        let pushedElements = Array(-10 ... 1_000)
+        let pushedElements = Array(-10...1_000)
         let expectedPoppedElements = Array(pushedElements.reversed())
         stack = Stack(pushedElements)
 

--- a/Collections/CollectionsTests/Stack/StackPushTests.swift
+++ b/Collections/CollectionsTests/Stack/StackPushTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackPushTests: XCTestCase {
     func test_push_addsElementToStack() {

--- a/Collections/CollectionsTests/Stack/StackTopTests.swift
+++ b/Collections/CollectionsTests/Stack/StackTopTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackTopTests: XCTestCase {
     func test_top_withEmptyStack_returnsNil() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsCountTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsCountTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsCountTests: XCTestCase {
     func test_count_withEmptyStack_returnsZero() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsGenericsTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsGenericsTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsGenericsTests: XCTestCase {
     func test_withVariousGenericParameters() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsIsEmptyTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsIsEmptyTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsIsEmptyTests: XCTestCase {
     func test_isEmpty_withEmptyStack_returnsTrue() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsIsStructureTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsIsStructureTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsIsStructureTests: XCTestCase {
     func test_stack_isStructure() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsMinimumElementTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsMinimumElementTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsMinimumElementTests: XCTestCase {
     private class DummyClass: Comparable {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsPopTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsPopTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsPopTests: XCTestCase {
     var stack = StackStatistics<Int>()
@@ -47,7 +47,7 @@ final class StackStatisticsPopTests: XCTestCase {
 
     func test_pop_withNonEmptyStack_returnsElementsAccordingToLifo() {
         // Given
-        let pushedElements = Array(-10 ... 1_000)
+        let pushedElements = Array(-10...1_000)
         let expectedPoppedElements = Array(pushedElements.reversed())
         stack = StackStatistics(pushedElements)
 

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsPushTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsPushTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsPushTests: XCTestCase {
     func test_push_addsElementToStack() {

--- a/Collections/CollectionsTests/StackStatistics/StackStatisticsTopTests.swift
+++ b/Collections/CollectionsTests/StackStatistics/StackStatisticsTopTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Collections
+import XCTest
 
 final class StackStatisticsTopTests: XCTestCase {
     func test_top_withEmptyStack_returnsNil() {

--- a/DemoApplications/macOS/DemoApplication/DemoApplication/main.swift
+++ b/DemoApplications/macOS/DemoApplication/DemoApplication/main.swift
@@ -1,6 +1,6 @@
 import Collections
 
-private let stackElements = [1, 2, 3]
+private let stackElements = [1]
 private let stack = Stack(stackElements)
 
 print("the stack with the elements \(stackElements) is empty - \(stack.isEmpty)")


### PR DESCRIPTION
Closes #51 
## List of changes
- fix imports order
- fix `magic_numbers` warning by removing unnecessary magic numbers form the `stackElements`
- fix `open-range` operator spacing
- fix `line_length` warning